### PR TITLE
HUD toggles and quest bug fix

### DIFF
--- a/Component.cs
+++ b/Component.cs
@@ -99,7 +99,9 @@ public class GTFOComponent : MonoBehaviour
         if (ExtractAndSwitchDisplayActive)
         {
             GUIHelper.DrawExtracts(ExtractAndSwitchDisplayActive, ExtractManager.extractPositions, ExtractManager.extractDistances, ExtractManager.extractNames, player);
-            GUIHelper.DrawPowerSwitches(ExtractAndSwitchDisplayActive);
+            
+            if (GTFOPlugin.showPowerSwitches.Value)
+                GUIHelper.DrawPowerSwitches(ExtractAndSwitchDisplayActive);
         }
 
         if (questDisplayActive)

--- a/GUIHelper.cs
+++ b/GUIHelper.cs
@@ -129,6 +129,11 @@ namespace GTFO
                             GUI.DrawTexture(iconRect, extractIcon);
 
                             string label = $"Distance: {extractDistances[i]:F2} meters";
+                            if (!GTFOPlugin.showPrefixes.Value)
+                            {
+                                label = $"{extractDistances[i]:F2} meters";
+                            }
+
 
                             // Position the label directly below the icon
                             float adjustedY = screenPosition.y + iconSize / 2;
@@ -141,6 +146,10 @@ namespace GTFO
                     {
                         // Draw text label
                         string label = $"Extract Name: {extractNames[i]}\nDistance: {extractDistances[i]:F2} meters";
+                        if (!GTFOPlugin.showPrefixes.Value)
+                        {
+                            label = $"{extractNames[i]}\n{extractDistances[i]:F2} meters";
+                        }
 
                         float adjustedY = screenPosition.y - labelHeight / 2;
                         GUI.Label(new Rect(screenPosition.x - labelWidth / 2, adjustedY, labelWidth, labelHeight), label, extractStyle);
@@ -317,6 +326,11 @@ namespace GTFO
                                     GUI.DrawTexture(iconRect, questIcon);
 
                                     string label = $"Distance: {Vector3.Distance(questPosition, GTFOComponent.player.Position):F2} meters";
+                                    if (!GTFOPlugin.showPrefixes.Value)
+                                    {
+                                        label = $"{Vector3.Distance(questPosition, GTFOComponent.player.Position):F2} meters";
+                                    }
+
                                     float labelHeight = 20 * scaleFactor;
                                     float labelWidth = 200 * scaleFactor;
 
@@ -343,6 +357,11 @@ namespace GTFO
                                 }
 
                                 string label = $"Quest Name: {nameText}\nDescription: {description}\nDistance: {Vector3.Distance(questPosition, GTFOComponent.player.Position):F2} meters";
+                                if (!GTFOPlugin.showPrefixes.Value)
+                                {
+                                    label = $"{nameText}\n----\n{description}\n----\n{Vector3.Distance(questPosition, GTFOComponent.player.Position):F2} meters";
+                                }
+
                                 float labelHeight = 100 * scaleFactor;
                                 float labelWidth = 200 * scaleFactor;
 

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -19,6 +19,8 @@ namespace GTFO
         }
 
         internal static ConfigEntry<bool> enabledPlugin;
+        internal static ConfigEntry<bool> showPrefixes;
+        internal static ConfigEntry<bool> showPowerSwitches;
         internal static ConfigEntry<float> extractDistanceLimit;
         internal static ConfigEntry<float> questDistanceLimit;
         internal static ConfigEntry<KeyboardShortcut> extractKeyboardShortcut;
@@ -49,7 +51,21 @@ namespace GTFO
                 "1. Main Settings",
                 "Enable Mod",
                 true,
-                new ConfigDescription("Enable the plugin to show with extracts/quests objectives", null, new ConfigurationManagerAttributes { Order = 7 })
+                new ConfigDescription("Enable the plugin to show with extracts/quests objectives", null, new ConfigurationManagerAttributes { Order = 9 })
+            );
+
+            showPrefixes = Config.Bind(
+                "1. Main Settings",
+                "Show Prefixes",
+                true,
+                new ConfigDescription("Show 'Quest Name:', 'Extract Name:'", null, new ConfigurationManagerAttributes { Order = 8 })
+            );
+
+            showPowerSwitches = Config.Bind(
+                "1. Main Settings",
+                "Show Power Switches",
+                true,
+                new ConfigDescription("Show Power Switches", null, new ConfigurationManagerAttributes { Order = 7 })
             );
 
             displayTime = Config.Bind(


### PR DESCRIPTION
- Config toggles for Power Switches and Prefixes ("Quest Name:", "Extract Name")
- "Quests that must be completed in one raid should now properly display markers for conditions that were reset"

I sent the initial bug fix to the author of Dynamic Maps as they had the bug too. They refactored the code a bit and allowed me to add it to this pull request!